### PR TITLE
CC upgrade editor

### DIFF
--- a/js/templates/modals/editListing/editListing.html
+++ b/js/templates/modals/editListing/editListing.html
@@ -120,7 +120,7 @@
               <div class="col12">
                 <label for="editListingDescription"><%= ob.polyT('editListing.description') %></label>
                 <% if (ob.errors['listing.item.description']) print(ob.formErrorTmpl({ errors: ob.errors['listing.item.description'] })) %>
-                <div contenteditable class="rows6" name="listing.item.description" id="editListingDescription"><%= ob.listing.item.description %></div>
+                <div contenteditable class="rows6 clrBr" name="listing.item.description" id="editListingDescription"><%= ob.listing.item.description %></div>
               </div>
             </div>
           </form>

--- a/js/utils/trumbowyg.js
+++ b/js/utils/trumbowyg.js
@@ -14,10 +14,22 @@ export const editorOptions = {
   ],
 };
 
-export function installRichEditor(attachPoint, editorOpts = editorOptions) {
+export function installRichEditor(attachPoint, options = {}) {
+  const opts = {
+    editorOptions,
+    ...options,
+  };
+
   // accept a selector, element, or jQuery object
   const attach = $(attachPoint);
 
   // create editor
-  attach.trumbowyg(editorOpts);
+  attach.trumbowyg(opts.editorOptions);
+
+  if (opts.topLevelClass) {
+    attach.closest('.trumbowyg')
+      .addClass(opts.topLevelClass);
+  }
+
+  return attach;
 }

--- a/js/views/modals/editListing/EditListing.js
+++ b/js/views/modals/editListing/EditListing.js
@@ -824,7 +824,10 @@ export default class extends BaseModal {
       this.$shippingOptionsWrap.append(shipOptsFrag);
 
       setTimeout(() => {
-        installRichEditor(this.$('#editListingDescription'));
+        installRichEditor(this.$('#editListingDescription'), {
+          topLevelClass: 'clrBr',
+        });
+
         if (!this.rendered) {
           this.rendered = true;
           this.$titleInput.focus();

--- a/styles/_theme.scss
+++ b/styles/_theme.scss
@@ -109,6 +109,20 @@ input[type=range][class~="clrS"] {
     border-color: $border;
   }
 
+  &.trumbowyg {
+    border-width: 0;
+
+    .trumbowyg-button-pane {
+      border: 1px solid $border;
+     
+      border-bottom: 0;
+
+      .trumbowyg-button-group::before {
+        background-color: $border;
+      }
+    }
+  }
+
   .btn:hover,
   .btn:focus,
   &.btn:hover,
@@ -133,6 +147,20 @@ input[type=range][class~="clrS"] {
   hr {
     border-color: $border2;
   }
+
+  &.trumbowyg {
+    border-width: 0;
+
+    .trumbowyg-button-pane {
+      border: 1px solid $border2;
+     
+      border-bottom: 0;
+
+      .trumbowyg-button-group::before {
+        background-color: $border2;
+      }
+    }
+  }  
 
   .btn:hover,
   .btn:focus,
@@ -267,7 +295,8 @@ input[type=range][class~="clrS"] {
 input,
 select,
 textarea,
-button {
+button,
+.trumbowyg div[contenteditable]{
   &:focus {
     border-color: $border3;
   }

--- a/styles/components/_form.scss
+++ b/styles/components/_form.scss
@@ -19,7 +19,7 @@ textarea::-webkit-input-placeholder {
 input,
 select,
 textarea,
-.trumbowyg div[contenteditable] {
+.trumbowyg-editor {  
   border: none;
   outline: none;
   background: none;
@@ -29,6 +29,14 @@ textarea,
     family: "Noto Sans", sans-serif;
     size: $tx5;
   }
+}
+
+.trumbowyg-editor {
+  border-radius: 0;
+}
+
+.trumbowyg textarea {
+  display: none;
 }
 
 .select2-container--focus .select2-selection__rendered,
@@ -45,7 +53,7 @@ input[type="text"],
 textarea,
 .select2-container--focus .select2-selection__rendered,
 .select2Tags + .select2-container .select2-container--default .select2-selection--multiple .select2-selection__rendered,
-.trumbowyg div[contenteditable] {
+.trumbowyg-editor {
   border-style: solid;
   border-width: 1px;
   //use the color class to set the border color


### PR DESCRIPTION
Hey @tenthhuman - so this is a branch with CSS tweaks to make the Trumbo editor play nice with our theming set-up (which turns out was a bit of a pain). Anyhow, this PR is set to merge into your branch, so if it looks good to you go ahead and merge it and re-push your upgrade-editor branch back up to the main repo.

Colors a bit tricky in our app because it's completely themeable. In Settings (hasn't been fully ipmlemented yet) the user can choose a palette of colors that the app will be "themed" in.

Anyways, these changes integrate the theme colors with the Trumbo editor. As an example (an ugly one), here I set the text color to blue and the border color to green:

![image](https://cloud.githubusercontent.com/assets/794517/21434293/95739204-c828-11e6-8868-a0dfe34fcda5.png)

It's not perfect, because I think we'd also want the background color behind those icons to pick up the theme background color and also the text of the icons to pickup the theme text color, but... this PR puts code in place to support that. Later, I imagine we'll have a ticket to cleanup some theming issues, since I've noticed other parts of the app also not playing nice with the theme (e.g. our select2 widget).